### PR TITLE
Fix/toml config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /target/
 **/*.rs.bk
 build.sh
+
+.idea

--- a/config/config.toml
+++ b/config/config.toml
@@ -1,3 +1,5 @@
+allowed_failures = 0
+
 # --- JENKINS ---
 
 jenkins_username = ""


### PR DESCRIPTION
Seems like `allowed_failures` should be in the config file. Without it running the binary app gives me:
```
Failed to deserialize config file. Error: missing field `allowed_failures`
```